### PR TITLE
Fix links to next lab

### DIFF
--- a/docs/class5/lab02/lab02.rst
+++ b/docs/class5/lab02/lab02.rst
@@ -80,6 +80,6 @@ Pay close attention to:
 
 This concludes Ticket 2.
 
-Go to `Ticket 03 - Determine Last Application Outage <../lab03/lab03.html>`_
+Go to `Ticket 03 - Determine Last Application Outage <../lab03/lab03.rst>`_
 
-Go to `Overview <../overview.html>`_
+Go to `Overview <../overview.rst>`_


### PR DESCRIPTION
Updated links in lab02.rst to point to .rst files instead of .html.