### PR TITLE
Remove "Standard" from Title

### DIFF
--- a/docs/class5/lab04/lab04.rst
+++ b/docs/class5/lab04/lab04.rst
@@ -1,4 +1,4 @@
-Ticket 04 – Review Connection Count Standard Deviation (VS)
+Ticket 04 – Review Connection Count Deviation (VS)
 ============================================================
 
 Title: “Why are some virtual servers showing connection count deviations?”


### PR DESCRIPTION
The title of this lab is "Review Connection Count Standard Deviation". However, a "standard deviation" is a specific term in statistics, which does not appear to be part of this lab and dashboard. It would be more correct to just say "deviation".
Feel free to reject this PR if you disagree.