### PR TITLE
Removed Inside Comment from Text

### DIFF
--- a/docs/class5/lab04/lab04.rst
+++ b/docs/class5/lab04/lab04.rst
@@ -60,8 +60,7 @@ Tasks
     - Yellow indicates Warning
     - Green indicates Normal/Good
 
-  Select a Virtual Server in a "Critical" state with highest deviation score
-  (in future, browse other Virtual Servers).
+  Select a Virtual Server in a "Critical" state with highest deviation score.
 
   The graph above will update based on your selection.
 


### PR DESCRIPTION
One of the tasks is "Select a Virtual Server in a “Critical” state with highest deviation score (in future, browse other Virtual Servers)." The part within parenthesis, "in future, browse...", appears to be an inside comment that was never intended to appear in the final version of the lab. This PR removes it. If this text actually *is* intended to be seen by the end user, you can reject this PR.