### PR TITLE
Update lab08.rst

### DIFF
--- a/docs/class5/lab08/lab08.rst
+++ b/docs/class5/lab08/lab08.rst
@@ -46,7 +46,7 @@ Tasks
 
   In Insight, review any available HTTP-related metrics or attributes
   for Backup_app and its pool app-1 that indicate HTTP protocol behavior
-  (for example, headers, connection reuse, or profile details).  This can be done by going to: **Dashboards >> BIG-IP Device >> LTM-Profile** and select the **EastRegion-bigip-01** and **/common/http**
+  (for example, headers, connection reuse, or profile details).  This can be done by going to: **Dashboards >> BIG-IP Device >> LTM-Profile** and select the **CentralRegion-bigip-01** and **/common/http**
 
   Using the charts on that page summarize whether *Backup_app* is effectively using HTTP/1.0 or a newer
   version on the client side, and whether server-side connections to the


### PR DESCRIPTION
Fix device name inconsistency in lab08. This PR fixes a mismatch in lab08.rst where the instructions reference
EastRegion-bigip-01 instead of CentralRegion-bigip-01.